### PR TITLE
fix: print a more friendly message when reading a file fails

### DIFF
--- a/src/memory/parser.cc
+++ b/src/memory/parser.cc
@@ -96,6 +96,12 @@ namespace parser
     Print(info[1], "json parse", "start", 0);
     int64_t jsonparse_start = uv_hrtime();
     std::ifstream jsonfile(parser->filename_);
+    if (!jsonfile.is_open()) {
+      std::cout << "\nfailed to open " << parser->filename_ << '\n';
+      std::cerr << "ParseError: " << strerror(errno);
+      std::exit(1);
+      return;
+    }
     json profile;
     jsonfile >> profile;
     jsonfile.close();


### PR DESCRIPTION
当我下载了一个快照到本地的 Downloads 目录，然后使用 devtoolx 开始分析的时候报了下面的错误，此时我不太清楚如何修复这个问题
![image](https://github.com/noslate-project/devtoolx/assets/23253540/2d89208c-2729-477a-aa54-d4f888f7c80c)
我 debug 了一下发现是文件权限问题，于是提了这个 pr，来让用户更加清楚的知道发生了什么错误，最后用户把快照移到到有权限的目录就能正常运行 devtoolx 了
下面是我修改代码后的运行测试，第 1 次是没有权限的场景，第 2 次是有权限正常运行的场景
![image](https://github.com/noslate-project/devtoolx/assets/23253540/ea0f090a-0e24-4508-b607-bc6778faf9af)

最后感谢 devtoolx 贡献者，非常好用 ~
